### PR TITLE
Add 'accepted' status and update event booking flow with new accept API

### DIFF
--- a/src/event/dto/confirm-booking.dto.ts
+++ b/src/event/dto/confirm-booking.dto.ts
@@ -4,6 +4,7 @@ enum BookingStatus {
   CONFIRMED = 'confirmed',
   REJECTED = 'rejected',
   CANCELLED = 'cancelled',
+  ACCEPTED = 'accepted',
 }
 
 export class ConfirmBookingDto {
@@ -25,4 +26,10 @@ export class CancelBookingDto {
   @IsString()
   @IsNotEmpty({ message: 'Reason is required when status is REJECTED' })
   reason?: string;
+}
+
+export class AcceptBookingDto {
+  @IsEnum(BookingStatus)
+  @IsNotEmpty()
+  status: BookingStatus.ACCEPTED;
 }

--- a/src/event/event.controller.ts
+++ b/src/event/event.controller.ts
@@ -20,7 +20,7 @@ import { UserRole } from '../users/interfaces/user.interface';
 import { AddIngredientsDto } from './dto/add-ingredients.dto.ts';
 import { AttendanceDto } from './dto/attendance.dto';
 import { BookingDto } from './dto/booking.dto';
-import { CancelBookingDto, ConfirmBookingDto } from './dto/confirm-booking.dto';
+import { CancelBookingDto, ConfirmBookingDto, AcceptBookingDto } from './dto/confirm-booking.dto';
 import { EventService } from './event.service';
 import { GetEventQueryType } from './interfaces/event.interface';
 
@@ -127,6 +127,28 @@ export class EventController {
     } catch (error) {
       throw new HttpException(
         error.message || 'Failed to confirm booking',
+        error.status || HttpStatus.INTERNAL_SERVER_ERROR,
+      );
+    }
+  }
+
+  @Post(':eventId/accept')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(UserRole.CHEF)
+  async acceptBooking(
+    @Param('eventId') eventId: string,
+    @Body() acceptBookingDto: AcceptBookingDto,
+    @Req() req: RequestUser,
+  ) {
+    try {
+      return await this.eventService.acceptBooking(
+        req.user._id.toString(),
+        eventId,
+        acceptBookingDto,
+      );
+    } catch (error) {
+      throw new HttpException(
+        error.message || 'Failed to accept booking',
         error.status || HttpStatus.INTERNAL_SERVER_ERROR,
       );
     }

--- a/src/event/interfaces/event.interface.ts
+++ b/src/event/interfaces/event.interface.ts
@@ -5,6 +5,7 @@ import { LocationType } from 'src/common/interfaces/location.interface';
 
 export enum EventStatus {
   PENDING = 'pending',
+  ACCEPTED = 'accepted',
   CONFIRMED = 'confirmed',
   REJECTED = 'rejected',
   CANCELLED = 'cancelled',


### PR DESCRIPTION
- Added a new ACCEPTED status to the event booking flow.
- Introduced a new API endpoint: POST /event/:eventId/accept for chefs to accept booking requests.
- Updated the event confirmation logic: events can now only be confirmed after being accepted (no direct pending → confirmed transition).
- Modified the event status enum and schema to include the new accepted status.
- Updated DTOs and validation to support the new status and flow.